### PR TITLE
Fixing deprecation warning for rational_reconstruct

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,106 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json

--- a/src/lefschetz_family/numperiods/interpolation.py
+++ b/src/lefschetz_family/numperiods/interpolation.py
@@ -109,12 +109,12 @@ class EvaluationInterpolation:
         A = self.spt[0]
         B = self.interpolate(values)
         try:
-            numer, denom = B.rational_reconstruct(A)
+            numer, denom = B.rational_reconstruction(A)
             if numer.degree() + denom.degree() + 1 < len(values):
                 return numer, denom
             else:
                 return None
-        except:                 # rational_reconstruct fails with an exception.
+        except:                 # rational_reconstruction fails with an exception.
             return None
 
     def _rational_interpolate_qq(self, values):


### PR DESCRIPTION
Fixing the following deprecation warning:
```
/Applications/sage/local/var/lib/sage/venv-python3.13/lib/python3.13/site-packages/lefschetz_family/numperiods/interpolation.py:112: DeprecationWarning: rational_reconstruct is deprecated. Please use rational_reconstruction instead.
See https://github.com/sagemath/sage/issues/12696 for details.
  numer, denom = B.rational_reconstruct(A)
```

Also, [rational_reconstruction](https://doc.sagemath.org/html/en/reference/polynomial_rings/sage/rings/polynomial/polynomial_element.html#sage.rings.polynomial.polynomial_element.Polynomial.rational_reconstruction) already puts bounds on the numerator and denominator, so this might not be needed:
```python3
if numer.degree() + denom.degree() + 1 < len(values):
```

