### PR TITLE
Fix VoronoiDiagram deprecation warning by adding explicit sort=True

### DIFF
--- a/src/lefschetz_family/numperiods/family.py
+++ b/src/lefschetz_family/numperiods/family.py
@@ -380,7 +380,7 @@ class Family(object):
         gr = Graph()
 
         # This is slow
-        for pt_, reg in vd.regions().items():
+        for pt_, reg in vd.regions(sort=True).items():
             pt = tuple(pt_)
             pt = pt[0] + I*pt[1]
             ptc = CDF(pt)

--- a/src/lefschetz_family/voronoi.py
+++ b/src/lefschetz_family/voronoi.py
@@ -295,7 +295,7 @@ class FundamentalGroupVoronoi(object):
             self._rootapprox = rootapprox
 
             polygons_temp = [] # first we collect all polygons and translate the centers in rational coordinates
-            for pt, reg in vd.regions().items():
+            for pt, reg in vd.regions(sort=True).items():
                 center = Util.select_closest(rootapprox, self.rationalize(self.point_to_complex_number(pt.affine())))
                 
                 polygons_temp += [[center, reg]]


### PR DESCRIPTION
Do you care about the sorting? if not then perhaps sort=False should be set.

Trying to silence the warning:
```
[/home/sage/sage-10.5/local/var/lib/sage/venv-python3.12.5/lib/python3.12/site-packages/lefschetz_family/voronoi.py:88](http://localhost:7072/home/sage/sage-10.5/local/var/lib/sage/venv-python3.12.5/lib/python3.12/site-packages/lefschetz_family/voronoi.py#line=87): DeprecationWarning: parameter 'sort' will be set to False by default in the future
See https://github.com/sagemath/sage/issues/35889 for details.
  for center, polygon in self.polygons:
  ```